### PR TITLE
Minor fixes to installed paths, update readme

### DIFF
--- a/1_create_package/conf.d/server.json
+++ b/1_create_package/conf.d/server.json
@@ -1,0 +1,15 @@
+{
+"bind_addr": "192.168.2.113", 
+"datacenter": "dc1",
+"data_dir": "/volume1/@appstore/consul/data",
+"encrypt": "changeme",
+"log_level": "INFO",
+"enable_syslog": true,
+"enable_debug": true,
+"node_name": "consul1",
+"server": true,
+"bootstrap_expect": 1,
+"leave_on_terminate": false,
+"skip_leave_on_interrupt": true,
+"rejoin_after_leave": true
+}

--- a/2_create_project/INFO
+++ b/2_create_project/INFO
@@ -1,5 +1,5 @@
 package="consul"
-version="1.4.4"
+version="1.8.4"
 description="Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure."
 support_url="https://github.com/hashicorp/consul/"
 displayname="consul"

--- a/2_create_project/scripts/installer
+++ b/2_create_project/scripts/installer
@@ -11,10 +11,10 @@ PATH="${INSTALL_DIR}:${PATH}"
 SERVICETOOL="/usr/syno/bin/servicetool"
 FWPORTS="/var/packages/${DNAME}/scripts/${PACKAGE}.sc"
 
-FILE_CREATE_LOG="${INSTALL_DIR}/consul/wizard_create_log"
+FILE_CREATE_LOG="${INSTALL_DIR}/wizard_create_log"
 LOG_FILE="/var/log/consul.log"
 
-CONF_DIR="${INSTALL_DIR}/consul/conf.d"
+CONF_DIR="${INSTALL_DIR}/conf.d"
 
 BACKUP_DIR="/tmp/consul_backup"
 

--- a/2_create_project/scripts/start-stop-status
+++ b/2_create_project/scripts/start-stop-status
@@ -7,9 +7,8 @@ DNAME="consul"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
-DIR_CONSUL="${INSTALL_DIR}/consul"
-CONSUL="${DIR_CONSUL}/consul"
-CONF_DIR="${DIR_NAME}/conf.d"
+CONSUL="${INSTALL_DIR}/consul"
+CONF_DIR="${INSTALL_DIR}/conf.d"
 ALT_CONF_DIR="/etc/consul"
 PID_FILE="/var/run/consul.pid"
 LOG_FILE="/var/log/consul.log"
@@ -21,7 +20,7 @@ then
 fi
 ARGS="agent -config-dir=${CONF_DIR}"
 
-export HOME=${DIR_CONSUL}
+export HOME=${INSTALL_DIR}
 export USER=root
 export USERNAME=root
 

--- a/2_create_project/scripts/start-stop-status
+++ b/2_create_project/scripts/start-stop-status
@@ -7,7 +7,7 @@ DNAME="consul"
 
 # Others
 INSTALL_DIR="/usr/local/${PACKAGE}"
-CONSUL="${INSTALL_DIR}/consul"
+CONSUL="${INSTALL_DIR}/consul/consul"
 CONF_DIR="${INSTALL_DIR}/conf.d"
 ALT_CONF_DIR="/etc/consul"
 PID_FILE="/var/run/consul.pid"
@@ -18,7 +18,7 @@ if [ -d "${ALT_CONF_DIR}" ];
 then
     CONF_DIR="${ALT_CONF_DIR}"
 fi
-ARGS="agent -config-dir=${CONF_DIR}"
+ARGS="agent -client 0.0.0.0 -server -config-dir=${CONF_DIR}"
 
 export HOME=${INSTALL_DIR}
 export USER=root

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can store your configuration using a `conf.d` folder inside `1_create_packag
 
 Download the binary from https://www.consul.io/downloads.html, replace the content from **1_create_package/consul** directory and exec create_spk.sh:
 
-```~/src/consul-spk(master)$ rm -rf 1_create_package/consul/ && unzip consul_1.4.4_linux_amd64.zip && mv consul ./1_create_package/```
+```~/src/consul-spk(master)$ rm -rf 1_create_package/consul/ && unzip consul_1.8.4_linux_amd64.zip && mv consul ./1_create_package/```
 
 ```$ sh create_spk.sh```
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,9 @@ Install Consul into a Synology NAS.
 
 Only tested on x64 (DS916+) could work on ARM since there an available consul binary.
 
-## Usage
-
-Change **Package Center -> Trust Level** to **Any Publisher** and import manually the package from **Manual install**.
-Finally, install with Consul web installation.
-
 ## Configuration
 
-You can store your configuration using a `conf.d` folder inside `1_create_package/consul/`. If you don't want to ship your configurations with the package, you can use `/etc/consul`.
+You can store your configuration using a `conf.d` folder inside `1_create_package/consul/`. If you don't want to ship your configurations with the package, you can use `/usr/local/consul/conf.d/`.
 
 ## To use with another arch
 


### PR DESCRIPTION
without this change it fails to start with:

```
myoung@bigNASty:~$ sudo cat /var/log/consul.log
Using configuration file in
/var/packages/consul/scripts/start-stop-status: line 31: /usr/local/consul/consul/consul: Not a directory
```

Because `/usr/local/consul/consul` is the binary and not a subdirectory

After this change consul is able to run successfully